### PR TITLE
Fix dependencies (gtk3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN apt-get update && apt-get install -y \
   libcap2 \
   libgconf-2-4 \
   libgnome-keyring-dev \
-  libgtk2.0-0 \
+  libgtk-3-0 \
+  libcanberra-gtk3-module \
   libnotify4 \
   libnss3 \
   libxkbfile1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@
 #    -v /var/run/dbus:/var/run/dbus \
 #    -v /var/run/user/$(id -u)/bus:/var/run/user/1000/bus \
 #    -e DBUS_SESSION_BUS_ADDRESS="unix:path=/var/run/user/1000/bus" \
+#    -v /var/run/user/$(id -u)/pulse:/var/run/user/1000/pulse \
+#    -e PULSE_SERVER="unix:/run/user/1000/pulse/native" \
 #    -e DISPLAY=unix$DISPLAY --rm --group-add $(getent group audio | cut -d: -f3) discord
 #
 #    # If this fails, it might either be SELinux or
@@ -45,6 +47,7 @@ RUN apt-get update && apt-get install -y \
   libgnome-keyring-dev \
   libgtk-3-0 \
   libcanberra-gtk3-module \
+  libpulse0 \
   libnotify4 \
   libnss3 \
   libxkbfile1 \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Note: SELinux on Fedora isn't too happy with this container (mostly to do with d
     -v /var/run/dbus:/var/run/dbus \
     -v /var/run/user/$(id -u)/bus:/var/run/user/1000/bus \
     -e DBUS_SESSION_BUS_ADDRESS="unix:path=/var/run/user/1000/bus" \
+    -v /var/run/user/$(id -u)/pulse:/var/run/user/1000/pulse \
+    -e PULSE_SERVER="unix:/run/user/1000/pulse/native" \
     -e DISPLAY=unix$DISPLAY \
     --rm \
     --group-add $(getent group audio | cut -d: -f3) \


### PR DESCRIPTION
I fixed dependencies because the current version of discord seems to use gtk3.
When I tested, no sound device is found in Discord.  So I made a change to use the host's Pulse audio server.  But I don't know if it's necessary.