### PR TITLE
Use `slim` variant for Debian Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@
 #    # Information about where stuff is
 #    docker volume inspect discordSettings
 
-FROM debian:stretch
+FROM debian:stretch-slim
 
 RUN apt-get update && apt-get install -y \
   libc++1 \


### PR DESCRIPTION
Updated the Base Image to use the `slim` variant for _Debian Stretch_, reducing the overall image size by ~20%, from 720MB to 574MB.